### PR TITLE
Bump commons-configuration2 from 2.7 to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.7</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Bumps commons-configuration2 from 2.7 to 2.8.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-configuration2 dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>